### PR TITLE
Add timeshift and series start

### DIFF
--- a/cmd/historygen/README.md
+++ b/cmd/historygen/README.md
@@ -11,6 +11,10 @@ time series foot print, say a year's worth of data, then this tool is for you.
             TSDB block length (default 2h0m0s)
       -c int
             Number of time series to generate (default 1)
+      -C int
+            Total number of time series to generate using multiple invocations (only needed for the zero padding of instance names)
+      -n int
+            Start index for time series instance names (default 0)
       -d duration
             Time duration of historical data to generate (default 720h0m0s)
       -s duration
@@ -28,7 +32,8 @@ of history (about a month) the tool would generate 360 TSDB blocks spanning
 the time range from the time the command was run until 720 hours ago.
 
 All time series generated have the name `test`, a `job="testdata"` label,
-and an `instance="test-metric-XXX"` where XXX is a zero based integer that
+and an `instance="test-metric-XXX"` where XXX is a zero based integer
+(unless otherwise specified by the `-n` option) that
 uniquely defines each time series as requested by the `-c` option.  Using
 `-c 500` would produce time series that look like:
 

--- a/cmd/historygen/README.md
+++ b/cmd/historygen/README.md
@@ -13,6 +13,8 @@ time series foot print, say a year's worth of data, then this tool is for you.
             Number of time series to generate (default 1)
       -d duration
             Time duration of historical data to generate (default 720h0m0s)
+      -s duration
+            Time shift of historical data to generate (default 0h)
       -i duration
             Duration between samples (default 15s)
       -o string
@@ -21,7 +23,7 @@ time series foot print, say a year's worth of data, then this tool is for you.
 Historygen will create the directory named by the `-o` option and populate
 it with TSDB blocks containing time series data.  Each block produced will
 have the duration specified by `-b` (block length).  The total amount of
-history to generate is controlled by `-d` for duration.  So, for 720 hours
+history to generate is controlled by `-d` and `-s` for duration.  So, for 720 hours
 of history (about a month) the tool would generate 360 TSDB blocks spanning
 the time range from the time the command was run until 720 hours ago.
 

--- a/cmd/historygen/historygen-hourly.sh
+++ b/cmd/historygen/historygen-hourly.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+echo "A script to generate Prometheus time series data for every hour across the last N hours"
+
+if [[ $# -ne 2 ]]; then
+  echo "$USAGE $0 <total-series> <total-hours>"
+  exit 1
+fi
+
+total_series=$1
+total_hours=$2
+series_batch=$[total_series/total_hours]
+
+rm -fr data
+for i in `seq $[total_hours-1] 0`; do
+  start=$[i+1]
+  echo "Processing hour -${start}h to -${i}h..."
+  ./historygen \
+    -C $total_series \
+    -c $series_batch \
+    -d 1h \
+    -b 1h \
+    -n $[i*series_batch] -s ${i}h
+done

--- a/cmd/historygen/main.go
+++ b/cmd/historygen/main.go
@@ -5,7 +5,7 @@ import (
 	"log"
 	"time"
 
-	"github.com/jjneely/stuff/tsdb"
+	"github.com/qcrisw/stuff/tsdb"
 )
 
 var (
@@ -17,6 +17,10 @@ var (
 		"Output directory to generate TSDB blocks in")
 	timeSeries = flag.Int("c", 1,
 		"Number of time series to generate")
+	totalTimeSeries = flag.Int("C", 0,
+		"Total number of time series to generate using multiple invocations (only needed for the zero padding of instance names)")
+	timeSeriesStartIndex = flag.Int("n", 0,
+		"Start index for time series instance names")
 	sampleInterval = flag.Duration("i", time.Second*15,
 		"Duration between samples")
 	blockLength = flag.Duration("b", time.Hour*2,
@@ -29,12 +33,14 @@ func main() {
 
 	endTime := time.Now().Add(-*timeShift)
 	err := tsdb.CreateThanosTSDB(tsdb.Opts{
-		OutputDir:      *outDir,
-		NumTimeseries:  *timeSeries,
-		StartTime:      endTime.Add(-*duration),
-		EndTime:        endTime,
-		SampleInterval: *sampleInterval,
-		BlockLength:    *blockLength,
+		OutputDir:            *outDir,
+		NumTimeseries:        *timeSeries,
+		TotalNumTimeSeries:   *totalTimeSeries,
+		TimeseriesStartIndex: *timeSeriesStartIndex,
+		StartTime:            endTime.Add(-*duration),
+		EndTime:              endTime,
+		SampleInterval:       *sampleInterval,
+		BlockLength:          *blockLength,
 	})
 
 	if err != nil {

--- a/cmd/historygen/main.go
+++ b/cmd/historygen/main.go
@@ -5,7 +5,7 @@ import (
 	"log"
 	"time"
 
-	"github.com/qcrisw/stuff/tsdb"
+	"github.com/jjneely/stuff/tsdb"
 )
 
 var (

--- a/cmd/historygen/main.go
+++ b/cmd/historygen/main.go
@@ -11,6 +11,8 @@ import (
 var (
 	duration = flag.Duration("d", time.Hour*720,
 		"Time duration of historical data to generate")
+	timeShift = flag.Duration("s", time.Hour*0,
+		"Time shift of historical data to generate")
 	outDir = flag.String("o", "data/",
 		"Output directory to generate TSDB blocks in")
 	timeSeries = flag.Int("c", 1,
@@ -25,7 +27,7 @@ func main() {
 	log.Printf("Generate Prometheus TSDB test data.")
 	flag.Parse()
 
-	endTime := time.Now()
+	endTime := time.Now().Add(-*timeShift)
 	err := tsdb.CreateThanosTSDB(tsdb.Opts{
 		OutputDir:      *outDir,
 		NumTimeseries:  *timeSeries,


### PR DESCRIPTION
This introduces 3 new options:
```
      -C int
            Total number of time series to generate using multiple invocations (only needed for the zero padding of instance names)
      -n int
            Start index for time series instance names (default 0)
      -s duration
            Time shift of historical data to generate (default 0h)
```
Combining these options allows for repeatedly calling `./historygen` on shifted times in the past,
instead of just the whole duration until now.
A new bash script is written to iterate though past hours and generate time series for each hour.
```
./historygen-hourly.sh 10000 24
A script to generate Prometheus time series data for every hour across the last N hours                                                                                                                                                            
Processing hour -24h to -23h...                                                                                                                                                                                                                    
2020/06/17 16:23:22 Generate Prometheus TSDB test data.                                                                                                                                                                                            
2020/06/17 16:23:23 TSDB data generation complete                                                                                                                                                                                                  
Processing hour -23h to -22h...                                                                                                                                                                                                                    
...
Processing hour -2h to -1h...                               
2020/06/17 16:23:29 Generate Prometheus TSDB test data.
2020/06/17 16:23:30 TSDB data generation complete
Processing hour -1h to -0h...                               
2020/06/17 16:23:30 Generate Prometheus TSDB test data.
2020/06/17 16:23:30 TSDB data generation complete
```