### PR TITLE
Fix chunk metadata's maxTime

### DIFF
--- a/tsdb/tsdb.go
+++ b/tsdb/tsdb.go
@@ -218,7 +218,7 @@ func populateChunks(series []*timeseries, outputDir string, blockStart time.Time
 			cm := chunks.Meta{
 				Chunk:   ch,
 				MinTime: chunkStartMs,
-				MaxTime: chunkStartMs + sampleInterval.Nanoseconds()/(1000*1000),
+				MaxTime: chunkStartMs + chunkLength.Nanoseconds()/(1000*1000),
 				Ref:     ref | (seg << 32),
 			}
 


### PR DESCRIPTION
Set chunk's max time to the timepoint of the maximum element in the
chunk (i.e. start + length). The previous behavior was adding ampleInterval
which is equivalent to just a single datapoint added. Suprisingly it
kind of works with the buggy version in  prometheus's graph view but has weird
behavior in the table view. E.g. when generating data in 1s intervals it
is able to show data from 0s to +5m10s (31 data points) but cannot show
any data thereafter.